### PR TITLE
Fix optional install prompt for software without install steps

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -139,6 +139,25 @@ func (o *Orchestrator) processSoftware(software config.Software, isOptional bool
 		}
 	} else {
 		if len(software.Install) == 0 {
+			if isOptional {
+				shouldInstall, err := o.promptForInstallation(&software)
+				if err != nil {
+					return err
+				}
+
+				if !shouldInstall {
+					if software.ShouldPersist() {
+						if err := o.state.SetExcluded(software.GetDisplayName()); err != nil {
+							return fmt.Errorf("failed to save exclusion state: %w", err)
+						}
+						fmt.Printf("  %s\n", colors.Dim("Skipped (choice saved)"))
+					} else {
+						fmt.Printf("  %s\n", colors.Dim("Skipped"))
+					}
+					return nil
+				}
+			}
+
 			fmt.Printf("  %s\n", colors.Warning("No installation steps defined, adding to checklist"))
 
 			// Prepare all checklist steps including the install step

--- a/internal/orchestrator/orchestrator_only_test.go
+++ b/internal/orchestrator/orchestrator_only_test.go
@@ -79,6 +79,7 @@ func TestRunOnlyTargetSingleMatch(t *testing.T) {
 		InstallGroups: []config.InstallGroup{
 			{
 				Group: "Test Group",
+				Optional: &[]bool{false}[0],
 				Software: []config.Software{
 					{
 						Name:      "Target Software",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -167,8 +167,8 @@ func TestProcessOptionalSoftwareWithoutInstallStepsDeclines(t *testing.T) {
 
 	// Write "n" to simulate user declining
 	go func() {
-		defer w.Close()
-		w.WriteString("n\n")
+		defer func() { _ = w.Close() }()
+		_, _ = w.WriteString("n\n")
 	}()
 
 	// Replace stdin temporarily
@@ -176,7 +176,7 @@ func TestProcessOptionalSoftwareWithoutInstallStepsDeclines(t *testing.T) {
 	os.Stdin = r
 	defer func() {
 		os.Stdin = oldStdin
-		r.Close()
+		_ = r.Close()
 	}()
 
 	software := config.Software{
@@ -223,8 +223,8 @@ func TestProcessOptionalSoftwareWithoutInstallStepsAccepts(t *testing.T) {
 
 	// Write "y" to simulate user accepting
 	go func() {
-		defer w.Close()
-		w.WriteString("y\n")
+		defer func() { _ = w.Close() }()
+		_, _ = w.WriteString("y\n")
 	}()
 
 	// Replace stdin temporarily
@@ -232,7 +232,7 @@ func TestProcessOptionalSoftwareWithoutInstallStepsAccepts(t *testing.T) {
 	os.Stdin = r
 	defer func() {
 		os.Stdin = oldStdin
-		r.Close()
+		_ = r.Close()
 	}()
 
 	software := config.Software{

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -130,7 +130,7 @@ func TestProcessSoftwareWithoutInstallSteps(t *testing.T) {
 		Artifact: "/nonexistent/Test.app",
 	}
 
-	err := o.processSoftware(software, true)
+	err := o.processSoftware(software, false)
 	if err != nil {
 		t.Fatalf("Process software should not error: %v", err)
 	}
@@ -142,6 +142,123 @@ func TestProcessSoftwareWithoutInstallSteps(t *testing.T) {
 
 	if len(content) == 0 {
 		t.Error("Checklist should not be empty")
+	}
+}
+
+func TestProcessOptionalSoftwareWithoutInstallStepsDeclines(t *testing.T) {
+	tempDir := t.TempDir()
+	checklistFile := filepath.Join(tempDir, "SystemSetup.md")
+
+	cfg := &config.Config{
+		Checklist: checklistFile,
+	}
+
+	o := New(cfg, t.TempDir())
+
+	if err := o.initializeForTesting(tempDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a pipe to simulate user declining the install
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write "n" to simulate user declining
+	go func() {
+		defer w.Close()
+		w.WriteString("n\n")
+	}()
+
+	// Replace stdin temporarily
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = oldStdin
+		r.Close()
+	}()
+
+	software := config.Software{
+		Name:     "Optional Test Software",
+		Artifact: "/nonexistent/OptionalTest.app",
+	}
+
+	err = o.processSoftware(software, true) // isOptional = true
+	if err != nil {
+		t.Fatalf("Process software should not error: %v", err)
+	}
+
+	// Checklist should remain empty since user declined
+	content, err := os.ReadFile(checklistFile)
+	if err != nil {
+		// File might not exist if no items were added, which is expected
+		if !os.IsNotExist(err) {
+			t.Fatalf("Failed to read checklist: %v", err)
+		}
+	} else if len(content) > 0 {
+		t.Error("Checklist should be empty when user declines optional install")
+	}
+}
+
+func TestProcessOptionalSoftwareWithoutInstallStepsAccepts(t *testing.T) {
+	tempDir := t.TempDir()
+	checklistFile := filepath.Join(tempDir, "SystemSetup.md")
+
+	cfg := &config.Config{
+		Checklist: checklistFile,
+	}
+
+	o := New(cfg, t.TempDir())
+
+	if err := o.initializeForTesting(tempDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a pipe to simulate user accepting the install
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write "y" to simulate user accepting
+	go func() {
+		defer w.Close()
+		w.WriteString("y\n")
+	}()
+
+	// Replace stdin temporarily
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = oldStdin
+		r.Close()
+	}()
+
+	software := config.Software{
+		Name:     "Optional Test Software",
+		Artifact: "/nonexistent/OptionalTest.app",
+	}
+
+	err = o.processSoftware(software, true) // isOptional = true
+	if err != nil {
+		t.Fatalf("Process software should not error: %v", err)
+	}
+
+	// Checklist should contain the install step since user accepted
+	content, err := os.ReadFile(checklistFile)
+	if err != nil {
+		t.Fatalf("Failed to read checklist: %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Error("Checklist should not be empty when user accepts optional install")
+	}
+
+	// Check that the install step was added
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "Install Optional Test Software") {
+		t.Error("Checklist should contain the install step")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where optional software items without installation steps were automatically added to the checklist without prompting the user first.

**Before**: Optional software without install steps was always added to checklist  
**After**: User is prompted "install <software>?" and only added if they confirm

## Changes Made

- Added user prompt for optional software without install steps in `orchestrator.go:142-158`
- Handle user decline with proper state management (exclusion tracking)
- Added comprehensive tests for both accept/decline scenarios
- Fixed existing test to properly specify non-optional group

## Test Plan

- [x] All existing tests pass
- [x] New test `TestProcessOptionalSoftwareWithoutInstallStepsDeclines` verifies user can decline
- [x] New test `TestProcessOptionalSoftwareWithoutInstallStepsAccepts` verifies user can accept  
- [x] Fixed `TestRunOnlyTargetSingleMatch` to use non-optional group
- [x] Manual testing shows proper prompting behavior

🤖 Generated with [Claude Code](https://claude.ai/code)